### PR TITLE
Fix build for GTK4 upstream and arm64 layout paths

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,7 +32,7 @@ apps:
       GTK_PATH: $SNAP/lib/gtk-4.0
       GTK_DATA_PREFIX: $SNAP
       XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
-      VK_ICD_FILENAMESr: /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.$SNAP_ARCH.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.$SNAP_ARCH.json
+      VK_ICD_FILENAMES: /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.$SNAP_ARCH.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.$SNAP_ARCH.json
     plugs:
       - opengl
       - audio-playback

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
       - cmake/latest/stable
     build-environment:
       - PATH: /snap/bin:$PATH
-      - LDFLAGS: "${LDFLAGS:+$LDFLAGS }-L/snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu -lharfbuzz"
+      - LDFLAGS: "${LDFLAGS:+$LDFLAGS }-L/snap/gnome-46-2404-sdk/current/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR -lharfbuzz"
     stage-packages:
       - libuv1
       - libglx-mesa0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,7 +90,7 @@ parts:
       - cmake/latest/stable
     build-environment:
       - PATH: /snap/bin:$PATH
-      - LDFLAGS: "${LDFLAGS:+$LDFLAGS }-lharfbuzz"
+      - LDFLAGS: "${LDFLAGS:+$LDFLAGS }-L/snap/gnome-46-2404-sdk/current/usr/lib/x86_64-linux-gnu -lharfbuzz"
     stage-packages:
       - libuv1
       - libglx-mesa0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,7 @@ parts:
       git submodule init
       git submodule update
       sed -i 's|RMT_ENABLED=1|RMT_ENABLED=0|g' submodules/CMakeLists.txt
-      make init
+      make init RELEASE_MODE=1
       craftctl set version=$(git describe --tags | cut -d- -f2-4 )
       cd build/r.linux
       ninja

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,28 +13,26 @@ confinement: strict
 compression: lzo
 
 layout:
-#  /usr/share/drirc.d:
-#    bind: $SNAP/usr/share/drirc.d
-  /usr/lib/x86_64-linux-gnu/dri:
-    bind: $SNAP/usr/lib/x86_64-linux-gnu/dri
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/dri
   /usr/share/vulkan:
     bind: $SNAP/usr/share/vulkan
-  /usr/lib/x86_64-linux-gnu/libvulkan_intel.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_intel.so
-  /usr/lib/x86_64-linux-gnu/libvulkan_lvp.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_lvp.so
-  /usr/lib/x86_64-linux-gnu/libvulkan_radeon.so:
-    bind-file: $SNAP/usr/lib/x86_64-linux-gnu/libvulkan_radeon.so
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_intel.so:
+    bind-file: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_intel.so
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_lvp.so:
+    bind-file: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_lvp.so
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_radeon.so:
+    bind-file: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libvulkan_radeon.so
 
 apps:
   b2:
     command: b2
     extensions: [gnome]
     environment:
-      GTK_PATH: $SNAP/lib/gtk-2.0
+      GTK_PATH: $SNAP/lib/gtk-4.0
       GTK_DATA_PREFIX: $SNAP
       XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
-      VK_ICD_FILENAMESr: /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.x86_64.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.x86_64.json
+      VK_ICD_FILENAMESr: /var/lib/snapd/lib/vulkan/icd.d/nvidia_icd.json:$SNAP/usr/share/vulkan/icd.d/radeon_icd.$SNAP_ARCH.json:$SNAP/usr/share/vulkan/icd.d/intel_icd.$SNAP_ARCH.json
     plugs:
       - opengl
       - audio-playback
@@ -85,7 +83,7 @@ parts:
       ninja
       cp ./src/b2/b2 $CRAFT_PART_INSTALL
       cp -a ./src/b2/assets $SNAPCRAFT_PART_INSTALL
-      mkdir -p $CRAFT_PART_INSTALL/lib/gtk-2.0
+      mkdir -p $CRAFT_PART_INSTALL/lib/gtk-4.0
       mkdir -p $CRAFT_PART_INSTALL/share/themes
       mkdir -p $CRAFT_PART_INSTALL/share/icons
     build-snaps:
@@ -95,23 +93,18 @@ parts:
     stage-packages:
       - libuv1
       - libglx-mesa0
-      # - libbrotli1
-      # - libcaca0
-      # - libtheora0
       - libgssapi-krb5-2
       - libicu74
       - libsphinxbase3
-      # - libmfx1
       - libcurl4
-      # - ffmpeg
       - libasn1-8-heimdal
       - libatk1.0-0
-      # - libbrotli1
       - libcurl3-gnutls
       - libdatrie1
       - libgdk-pixbuf2.0-0
-      # - libgssapi3-heimdal
-      - libgtk2.0-0
+      - libgtk-4-1
+      - libharfbuzz0b
+      - libharfbuzz-icu0
       - libhcrypto5t64-heimdal
       - libheimbase1-heimdal
       - libheimntlm0-heimdal
@@ -133,12 +126,11 @@ parts:
       - libxcomposite1
       - libfribidi0
       - libglx-mesa0
-      # - mesa-va-drivers
       - libsdl2-2.0-0
     build-packages:
       - libcurl4-gnutls-dev
       - uuid-dev
-      - libgtk2.0-dev
+      - libgtk-4-dev
       - libgl1-mesa-dev
       - libpulse-dev
       - libgles2-mesa-dev
@@ -149,4 +141,3 @@ parts:
       - libsdl2-dev
       - libsdl2-net-dev
       - libuv1-dev
-

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,6 +90,7 @@ parts:
       - cmake/latest/stable
     build-environment:
       - PATH: /snap/bin:$PATH
+      - LDFLAGS: "${LDFLAGS:+$LDFLAGS }-lharfbuzz"
     stage-packages:
       - libuv1
       - libglx-mesa0


### PR DESCRIPTION
Upstream b2 switched from GTK2 to GTK4 in the Mar 2026 release (`b2-20260322-193052-51e70d7`). This updates the snap to match.

**Changes:**

- **GTK2 → GTK4**: Replace `libgtk2.0-0`/`libgtk2.0-dev` with `libgtk-4-1`/`libgtk-4-dev`, and update `GTK_PATH` env var
- **Fix pango link error**: Add `libharfbuzz0b` and `libharfbuzz-icu0` to stage-packages — the gnome-46-2404-sdk's `libpangoft2` internally calls harfbuzz functions (`pango_font_description_get/set_features`) that need a consistent harfbuzz at link time; this was the error Tom hit in his attempts
- **Fix arm64 layout paths**: Replace hardcoded `x86_64-linux-gnu` in the layout section with `$CRAFT_ARCH_TRIPLET_BUILD_FOR` and `$SNAP_ARCH` so the snap can actually build and run on arm64

Ref: tom-seddon/b2#539

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the snap to GTK4 and make build/run paths arch-aware so arm64 builds and runs cleanly. Also fixes Pango/Harfbuzz linking and ensures the Vulkan ICD override takes effect.

- **Bug Fixes**
  - Switch to `libgtk-4-1`/`libgtk-4-dev` and set `GTK_PATH` to `lib/gtk-4.0`.
  - Fix Pango/Harfbuzz link by adding `libharfbuzz0b`/`libharfbuzz-icu0` and forcing `-lharfbuzz` from the SDK via `LDFLAGS` (uses `$CRAFT_ARCH_TRIPLET_BUILD_FOR`).
  - Replace hardcoded `x86_64-linux-gnu` with `$CRAFT_ARCH_TRIPLET_BUILD_FOR` and use `$SNAP_ARCH` in Vulkan ICD filenames for arm64.
  - Fix env var typo `VK_ICD_FILENAMESr` → `VK_ICD_FILENAMES`.
  - Run `make init` with `RELEASE_MODE=1` to skip sanitizer targets that fail on GCC/Linux, unblocking arm64 builds.

<sup>Written for commit 254feebccf0e7bf64fb213066afeaf977ed6ea38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

